### PR TITLE
fix for displays with width > 256

### DIFF
--- a/adafruit_ssd1608.py
+++ b/adafruit_ssd1608.py
@@ -69,7 +69,7 @@ class SSD1608(displayio.EPaperDisplay):
     def __init__(self, bus, **kwargs):
         start_sequence = bytearray(_START_SEQUENCE)
         width = kwargs["width"]
-        start_sequence[4] = width - 1
+        start_sequence[4] = (width - 1) & 0xff
         start_sequence[5] = (width - 1) >> 8
 
         super().__init__(bus, start_sequence, _STOP_SEQUENCE, **kwargs,


### PR DESCRIPTION
Currently setting width to a value higher than 256 results in the following exception:

    OverflowError: value must fit in 1 byte(s)

This PR fixes the issue.