### PR TITLE
Update with fourwire and display.root_group for CP 9 compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,7 @@ Usage Example
     import time
     import board
     import displayio
+    import fourwire
     import adafruit_ssd1608
 
     displayio.release_displays()
@@ -80,7 +81,7 @@ Usage Example
     epd_reset = board.D5
     epd_busy = board.D6
 
-    display_bus = displayio.FourWire(spi, command=epd_dc, chip_select=epd_cs, reset=epd_reset,
+    display_bus = fourwire.FourWire(spi, command=epd_dc, chip_select=epd_cs, reset=epd_reset,
                                      baudrate=1000000)
     time.sleep(1)
 
@@ -99,7 +100,7 @@ Usage Example
     # t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
     g.append(t)
 
-    display.show(g)
+    display.root_group = g
 
     display.refresh()
 

--- a/examples/ssd1608_simpletest.py
+++ b/examples/ssd1608_simpletest.py
@@ -11,6 +11,7 @@ Supported products:
 import time
 import board
 import displayio
+import fourwire
 import adafruit_ssd1608
 
 displayio.release_displays()
@@ -22,7 +23,7 @@ epd_dc = board.D10
 epd_reset = board.D5
 epd_busy = board.D6
 
-display_bus = displayio.FourWire(
+display_bus = fourwire.FourWire(
     spi, command=epd_dc, chip_select=epd_cs, reset=epd_reset, baudrate=1000000
 )
 time.sleep(1)
@@ -43,7 +44,7 @@ with open("/display-ruler.bmp", "rb") as f:
     # t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
     g.append(t)
 
-    display.show(g)
+    display.root_group = g
 
     display.refresh()
 


### PR DESCRIPTION
Fixes #16.
This PR adds removes `display.show` and replaces it with `display.root_group =` as well as updating to `fourwire.FourWire`